### PR TITLE
Update b-tagger, add year configuring, and edit ntuple info

### DIFF
--- a/LQResultProducer.py
+++ b/LQResultProducer.py
@@ -30,7 +30,9 @@ elif year == '2018':
 	NormalDirectory = '/eos/cms/store/group/phys_exotica/leptonsPlusJets/LQ/LQ2/stockNanoTrees/2018/gmadigan/NTupleAnalyzer_nanoAOD_Full2018QuickTest_stockNano_2020_07_05_00_00_41/SummaryFiles'
 	QCDDirectory    = '/eos/cms/store/group/phys_exotica/leptonsPlusJets/LQ/LQ2/trees/NTupleAnalyzer_nanoAOD_Full2016QCDNonIsoQuickTest_2019_10_14/SummaryFiles' #Placeholder
 	EMuDirectory    = '/eos/cms/store/group/phys_exotica/leptonsPlusJets/LQ/LQ2/trees/NTupleAnalyzer_nanoAOD_Full2016EMuSwitch_2019_10_14/SummaryFiles' #Placeholder
-else: exit()
+else:
+	print "Did not enter a valid year.\nPlease use option \'-y\' to select running year (2016,2017,2018)"
+	exit()
 
 # The name of the main ttree (ntuple structure)
 TreeName = "PhysicalVariables"
@@ -555,6 +557,7 @@ def main():
 		#munu2 = '(MT_uv>70)*(MT_uv<110)*(JetCount>3.5)'
 		[[Rz_uuj,Rz_uuj_err],[Rtt_uuj,Rtt_uuj_err]] = GetMuMuScaleFactors( NormalWeightMuMu+'*'+preselectionmumu_single, NormalDirectory, '(M_uu>80)*(M_uu<100)', '(M_uu>100)*(M_uu<250)',0,0)
 		[[Rz_uujj,Rz_uujj_err],[Rtt_uujj,Rtt_uujj_err]] = GetMuMuScaleFactors( NormalWeightMuMu+'*'+preselectionmumu, NormalDirectory, '(M_uu>80)*(M_uu<100)', '(M_uu>100)*(M_uu<250)',0,0)
+		#exit()
 		#[[Rz_uujj,Rz_uujj_err],[Rtt_uujj,Rtt_uujj_err]] = [[1.025,0.04],[1.147,0.019]]#TTBar MC, 2016 customNano
 		#[[Rz_uujj,Rz_uujj_err],[Rtt_uujj,Rtt_uujj_err]] = [[0.925,0.005],[1.000,0.023]]#TTBarDataDriven
 		#[[Rw_uvjj,Rw_uvjj_err],[Rtt_uvjj,Rtt_uvjj_err]] = [[0.977,0.052],[0.932,0.039]]#TTBarMC
@@ -5649,9 +5652,9 @@ def MakeBasicPlot(recovariable,xlabel,presentationbinning,selection,weight,FileD
 
 
 	MCStack=BeautifyStack(MCStack,Label)
-	#hs_rec_Signal.Draw("HISTSAME")
-	#if 'final' not in tagname:
-		#hs_rec_Signal2.Draw("HISTSAME")
+	hs_rec_Signal.Draw("HISTSAME")
+	if 'final' not in tagname:
+		hs_rec_Signal2.Draw("HISTSAME")
  	if 'PAS' in tagname and 'final' in tagname:
 		# sysTop.Draw("F")
 		hs_bgband.Draw("E2SAME")
@@ -5705,8 +5708,8 @@ def MakeBasicPlot(recovariable,xlabel,presentationbinning,selection,weight,FileD
 	if 'final' not in tagname:
 		if 'PAS' in tagname:
 			leg.AddEntry(hs_bgband,'Unc. (stat + syst)')
-		#leg.AddEntry(hs_rec_Signal,sig1name,"l")
-		#leg.AddEntry(hs_rec_Signal2,sig2name,"l")
+		leg.AddEntry(hs_rec_Signal,sig1name,"l")
+		leg.AddEntry(hs_rec_Signal2,sig2name,"l")
 	else:
 		if 'PAS' in tagname:
 			leg.AddEntry(hs_bgband,'Unc. (stat + syst)')

--- a/LQResultProducer.py
+++ b/LQResultProducer.py
@@ -1,5 +1,6 @@
 import os, sys, math, random, platform, time
 from glob import glob
+from argparse import ArgumentParser
 
 global preselectionmumu 
 
@@ -9,31 +10,41 @@ global preselectionmumu
 ########    GLOBAL VARIABLES NEEDED FOR PLOTS AND ANALYSIS        ########
 ##########################################################################
 
+# Input Options - file, cross-section, number of events
+#parser = OptionParser()
+parser = ArgumentParser()
+parser.add_argument("-y", "--year", dest="year", help="option to pick running year (2016,2017,2018)", metavar="YEAR")
+options = parser.parse_args()
+year = str(options.year)
+
 # Directory where root files are kept and the tree you want to get root files from
-
-if 'cmsneu' in platform.node():
-	#NormalDirectory = '/media/dataPlus/dmorse/lqNtuples/NTupleAnalyzer_Full2016_v236_HLT_2017_04_21_19_13_01/SummaryFiles'
-	#QCDDirectory    = '/media/dataPlus/dmorse/lqNtuples/NTupleAnalyzer_Full2016QCDNonIsoQuickTest_2017_11_09/SummaryFiles'
-	QCDDirectory    = '/media/dataPlus/dmorse/lqNtuples/NTupleAnalyzer_QCDNonIsoSwitch_1jetReq_2017_11_26/SummaryFiles'
-        #EMuDirectory    = '/media/dataPlus/dmorse/lqNtuples/NTupleAnalyzer_Full2016_v236_HLT_Ele40Cut_EMuSwitch_2017_05_29/SummaryFiles'
-	NormalDirectory = '/media/dataPlus/dmorse/lqNtuples/NTupleAnalyzer_muCuts_full_2017_09_04/SummaryFiles'
-	EMuDirectory    = '/media/dataPlus/dmorse/lqNtuples/NTupleAnalyzer_LQfull_HEEPtag_EMuSwitch_2017_10_10_09/SummaryFiles'
-
-else:
-	NormalDirectory = '/eos/cms/store/group/phys_exotica/leptonsPlusJets/LQ/LQ2/trees/NTupleAnalyzer_nanoAOD_Full2016QuickTest_2019_10_14/SummaryFiles'
-	QCDDirectory    = '/eos/cms/store/group/phys_exotica/leptonsPlusJets/LQ/LQ2/trees/NTupleAnalyzer_nanoAOD_Full2016QCDNonIsoQuickTest_2019_10_14/SummaryFiles'
-	EMuDirectory    = '/eos/cms/store/group/phys_exotica/leptonsPlusJets/LQ/LQ2/trees/NTupleAnalyzer_nanoAOD_Full2016EMuSwitch_2019_10_14/SummaryFiles'
+if year == '2016':
+	NormalDirectory = '/eos/cms/store/group/phys_exotica/leptonsPlusJets/LQ/LQ2/stockNanoTrees/2016/gmadigan/NTupleAnalyzer_nanoAOD_Full2016QuickTest_stockNano_2020_07_20_21_53_31/SummaryFiles'
+	QCDDirectory    = '/eos/cms/store/group/phys_exotica/leptonsPlusJets/LQ/LQ2/trees/NTupleAnalyzer_nanoAOD_Full2016QCDNonIsoQuickTest_2019_10_14/SummaryFiles' #Placeholder
+	EMuDirectory    = '/eos/cms/store/group/phys_exotica/leptonsPlusJets/LQ/LQ2/trees/NTupleAnalyzer_nanoAOD_Full2016EMuSwitch_2019_10_14/SummaryFiles' #Placeholder
+elif year == '2017':
+	NormalDirectory = '/eos/cms/store/group/phys_exotica/leptonsPlusJets/LQ/LQ2/stockNanoTrees/2017/gmadigan/NTupleAnalyzer_nanoAOD_Full2017QuickTest_stockNano_2020_05_04_21_47_24/SummaryFiles'
+	QCDDirectory    = '/eos/cms/store/group/phys_exotica/leptonsPlusJets/LQ/LQ2/trees/NTupleAnalyzer_nanoAOD_Full2016QCDNonIsoQuickTest_2019_10_14/SummaryFiles' #Placeholder
+	EMuDirectory    = '/eos/cms/store/group/phys_exotica/leptonsPlusJets/LQ/LQ2/trees/NTupleAnalyzer_nanoAOD_Full2016EMuSwitch_2019_10_14/SummaryFiles' #Placeholder
+elif year == '2018':
+	NormalDirectory = '/eos/cms/store/group/phys_exotica/leptonsPlusJets/LQ/LQ2/stockNanoTrees/2018/gmadigan/NTupleAnalyzer_nanoAOD_Full2018QuickTest_stockNano_2020_07_05_00_00_41/SummaryFiles'
+	QCDDirectory    = '/eos/cms/store/group/phys_exotica/leptonsPlusJets/LQ/LQ2/trees/NTupleAnalyzer_nanoAOD_Full2016QCDNonIsoQuickTest_2019_10_14/SummaryFiles' #Placeholder
+	EMuDirectory    = '/eos/cms/store/group/phys_exotica/leptonsPlusJets/LQ/LQ2/trees/NTupleAnalyzer_nanoAOD_Full2016EMuSwitch_2019_10_14/SummaryFiles' #Placeholder
+else: exit()
 
 # The name of the main ttree (ntuple structure)
 TreeName = "PhysicalVariables"
 
 # Integrated luminosity for normalization
-#lumi =  2318.348
-#lumi = 2690.707
-#lumi = 27192.225
-#lumi = 36455.377
-lumi = 35863.308
-
+if year == '2016':
+	lumi = 35920.
+	lumiInvfb = '35.9'
+elif year == '2017':
+	lumi = 41530.
+	lumiInvfb = '41.5'
+elif year == '2018':
+	lumi = 59740.
+	lumiInvfb = '59.7'
 
 #Muon HLT MC scale factor
 #https://twiki.cern.ch/twiki/bin/view/CMS/MuonReferenceEffsRun2
@@ -47,12 +58,6 @@ singlemuHLT = '*(mu1hltSF)'
 doublemuHLT = '*(1.0-((1.0-mu1hltSF)*(1.0-mu2hltSF)))'
 
 singlemuHLTEMUSF =  '*((IsMuon_muon1)*(0.949621*(Eta_muon1>-2.4)*(Eta_muon1<=-2.1)+0.967073*(Eta_muon1>-2.1)*(Eta_muon1<=-1.6)+1.02402*(Eta_muon1>-1.6)*(Eta_muon1<=-1.2)+0.958010*(Eta_muon1>-1.2)*(Eta_muon1<=-0.9)+0.986735*(Eta_muon1>-0.9)*(Eta_muon1<=-0.3)+0.923577*(Eta_muon1>-0.3)*(Eta_muon1<=-0.2)+0.975074*(Eta_muon1>-0.2)*(Eta_muon1<=0.0)+0.977559*(Eta_muon1>0.0)*(Eta_muon1<=0.2)+0.947337*(Eta_muon1>0.2)*(Eta_muon1<=0.3)+0.982190*(Eta_muon1>0.3)*(Eta_muon1<=0.9)+0.968889*(Eta_muon1>0.9)*(Eta_muon1<=1.2)+1.01164*(Eta_muon1>1.2)*(Eta_muon1<=1.6)+0.956268*(Eta_muon1>1.6)*(Eta_muon1<=2.1)+0.916149*(Eta_muon1>2.1)*(Eta_muon1<=2.4))+(IsMuon_muon2)*(0.949621*(Eta_muon2>-2.4)*(Eta_muon2<=-2.1)+0.967073*(Eta_muon2>-2.1)*(Eta_muon2<=-1.6)+1.02402*(Eta_muon2>-1.6)*(Eta_muon2<=-1.2)+0.958010*(Eta_muon2>-1.2)*(Eta_muon2<=-0.9)+0.986735*(Eta_muon2>-0.9)*(Eta_muon2<=-0.3)+0.923577*(Eta_muon2>-0.3)*(Eta_muon2<=-0.2)+0.975074*(Eta_muon2>-0.2)*(Eta_muon2<=0.0)+0.977559*(Eta_muon2>0.0)*(Eta_muon2<=0.2)+0.947337*(Eta_muon2>0.2)*(Eta_muon2<=0.3)+0.982190*(Eta_muon2>0.3)*(Eta_muon2<=0.9)+0.968889*(Eta_muon2>0.9)*(Eta_muon2<=1.2)+1.01164*(Eta_muon2>1.2)*(Eta_muon2<=1.6)+0.956268*(Eta_muon2>1.6)*(Eta_muon2<=2.1)+0.916149*(Eta_muon2>2.1)*(Eta_muon2<=2.4)))'
-
-bTag1SFmedium = '*(1-(1-(CMVA_bjet1>0.4432)*Hjet1BsfMedium)*(1-(CMVA_bjet2>0.4432)*Hjet2BsfMedium)*(1-(CMVA_Zjet1>0.4432)*Zjet1BsfMedium)*(1-(CMVA_Zjet2>0.4432)*Zjet2BsfMedium))'
-bTag1SFmediumUp = '*(1-(1-(CMVA_bjet1>0.4432)*Hjet1BsfMediumUp)*(1-(CMVA_bjet2>0.4432)*Hjet2BsfMediumUp)*(1-(CMVA_Zjet1>0.4432)*Zjet1BsfMediumUp)*(1-(CMVA_Zjet2>0.4432)*Zjet2BsfMediumUp))'
-bTag1SFmediumDown = '*(1-(1-(CMVA_bjet1>0.4432)*Hjet1BsfMediumDown)*(1-(CMVA_bjet2>0.4432)*Hjet2BsfMediumDown)*(1-(CMVA_Zjet1>0.4432)*Zjet1BsfMediumDown)*(1-(CMVA_Zjet2>0.4432)*Zjet2BsfMediumDown))'
-
-
 
 # This is for the case of the E-mu sample, where one "muon" is replaced by an electron. In that case, we check
 # which muon is a real muon (IsMuon_muon1) and apply the trigger efficiency based on the muon
@@ -104,12 +109,11 @@ eleHEEPScale = '*((1-IsMuon_muon1)*(((abs(Eta_muon1)>0.0)*(abs(Eta_muon1)<0.5)*0
 
 #BTAG scale factors
 #2016
-bTag1SFmedium = '*(1-(1-(CISV_jet1>0.8838)*bTagSF_jet1)*(1-(CISV_jet2>0.8838)*btagSF_jet2))' #fixme btag -> BTag
-bTag1SFmediumUp = '*(1-(1-(CISV_jet1>0.8838)*bTagSF_jet1Up)*(1-(CISV_jet2>0.8838)*bTagSF_jet2Up))'
-bTag1SFmediumDown = '*(1-(1-(CISV_jet1>0.8838)*bTagSF_jet1Down)*(1-(CISV_jet2>0.8838)*bTagSF_jet2Down))'
+bTag1SFmedium = '*(1-(1-(DeepJet_jet1>0.3033)*bTagSF_jet1)*(1-(DeepJet_jet2>0.3033)*bTagSF_jet2))' #fixme btag -> BTag
+bTag1SFmediumUp = '*(1-(1-(DeepJet_jet1>0.3033)*bTagSF_jet1Up)*(1-(DeepJet_jet2>0.3033)*bTagSF_jet2Up))'
+bTag1SFmediumDown = '*(1-(1-(DeepJet_jet1>0.3033)*bTagSF_jet1Down)*(1-(DeepJet_jet2>0.3033)*bTagSF_jet2Down))'
 
-bTagsel1medium = '*(((CISV_jet1>0.8838)+(CISV_jet2>0.8838))>0)'
-
+bTagsel1medium = '*(((DeepJet_jet1>0.3033)+(DeepJet_jet2>0.3033))>0)'
 
 # Weights for different MC selections, including integrated luminosity, event weight, and trigger weight
 #NormalWeightMuMu = str(lumi)+'*weight_central*((pass_HLTMu50+pass_HLTTkMu50)>0)'+doublemuHLT+doubleMuIdScale+doubleMuIsoScale+trackerHIP1+trackerHIP2
@@ -126,7 +130,9 @@ NormalWeightEMuNoHLT = str(lumi)+'*weight_central'+MuIdScaleEMU+MuIsoScaleEMU+el
 #ZptReweight = '*(0.95-0.1*TMath::Erf((Pt_mu1mu2_gen-14.0)/8.8))'
 
 # This is the real data trigger condition
-dataHLT = '*((pass_HLTMu50+pass_HLTTkMu50)>0)'
+dataHLT = '*0'
+if year == '2016': dataHLT = '*((pass_HLTMu50+pass_HLTTkMu50)>0)'
+elif year == '2017' or year == '2018': dataHLT = '*((pass_HLTMu50+pass_HLTOldMu100+pass_HLTTkMu100)>0)'
 
 # This is the set of event filters used
 #passfilter =  '*(passDataCert*passPrimaryVertex*(GoodVertexCount>=1))' #fixme json not working
@@ -315,7 +321,7 @@ def main():
 	# for this, and make use of it. e.g. For systematic variations, we can run in batch instead
 	# of running serially, which speeds things up.
 
-	version_name = 'Testing_2016_customNano' # scriptflag
+	version_name = 'Testing_'+year+'_stockNano' # scriptflag
 	#version_name = 'Testing_noQCD_14nov' # use sf tag above if this is the real folder
 	os.system('mkdir Results_'+version_name) 
 
@@ -549,7 +555,6 @@ def main():
 		#munu2 = '(MT_uv>70)*(MT_uv<110)*(JetCount>3.5)'
 		[[Rz_uuj,Rz_uuj_err],[Rtt_uuj,Rtt_uuj_err]] = GetMuMuScaleFactors( NormalWeightMuMu+'*'+preselectionmumu_single, NormalDirectory, '(M_uu>80)*(M_uu<100)', '(M_uu>100)*(M_uu<250)',0,0)
 		[[Rz_uujj,Rz_uujj_err],[Rtt_uujj,Rtt_uujj_err]] = GetMuMuScaleFactors( NormalWeightMuMu+'*'+preselectionmumu, NormalDirectory, '(M_uu>80)*(M_uu<100)', '(M_uu>100)*(M_uu<250)',0,0)
-                #exit()
 		#[[Rz_uujj,Rz_uujj_err],[Rtt_uujj,Rtt_uujj_err]] = [[1.025,0.04],[1.147,0.019]]#TTBar MC, 2016 customNano
 		#[[Rz_uujj,Rz_uujj_err],[Rtt_uujj,Rtt_uujj_err]] = [[0.925,0.005],[1.000,0.023]]#TTBarDataDriven
 		#[[Rw_uvjj,Rw_uvjj_err],[Rtt_uvjj,Rtt_uvjj_err]] = [[0.977,0.052],[0.932,0.039]]#TTBarMC
@@ -583,7 +588,6 @@ def main():
 		MakeBasicPlot("Pt_miss","E_{T}^{miss} [GeV]",metzoombinning_uujj_Z,preselectionmumu+'*(M_uu>80)*(M_uu<100)*(Pt_miss<100)',NormalWeightMuMu,NormalDirectory,'controlzoom_ZRegion','uujj',Rz_uujj, Rw_uvjj,Rtt_uujj,'',version_name,1000)
 		MakeBasicPlot("M_uu","M^{#mu#mu} [GeV]",bosonzoombinning_uujj_TT,preselectionmumu+'*(M_uu>100)*(Pt_miss>=100)',NormalWeightMuMu,NormalDirectory,'controlzoom_TTRegion','uujj',Rz_uujj, Rw_uvjj,Rtt_uujj,'',version_name,1000)
 		MakeBasicPlot("Pt_miss","E_{T}^{miss} [GeV]",metzoombinning_uujj_TT,preselectionmumu+'*(M_uu>100)*(Pt_miss>=100)',NormalWeightMuMu,NormalDirectory,'controlzoom_TTRegion','uujj',Rz_uujj, Rw_uvjj,Rtt_uujj,'',version_name,1000)
-		exit()
 		#MakeBasicPlot("CISV_jet1","Jet1 CSV score",bjetbinning,preselectionmunu+'*(MT_uv>70)*(MT_uv<150)*(JetCount<3.5)',NormalWeightMuNu,NormalDirectory,'controlzoom_WRegion','uvjj',Rz_uujj, Rw_uvjj,Rtt_uvjj,'',version_name,850)
 		#MakeBasicPlot("CISV_jet2","Jet2 CSV score",bjetbinning,preselectionmunu+'*(MT_uv>70)*(MT_uv<150)*(JetCount<3.5)',NormalWeightMuNu,NormalDirectory,'controlzoom_WRegion','uvjj',Rz_uujj, Rw_uvjj,Rtt_uvjj,'',version_name,850)
 		#MakeBasicPlot("CISV_jet1","Jet1 CSV score",bjetbinning,preselectionmunu+'*(MT_uv>70)*(MT_uv<150)*(JetCount>3.5)',NormalWeightMuNu,NormalDirectory,'controlzoom_TTRegion','uvjj',Rz_uujj, Rw_uvjj,Rtt_uvjj,'',version_name,850)
@@ -635,6 +639,8 @@ def main():
 		# UUJJ plots at preselection, Note that putting 'TTBarDataDriven' in the name turns on the use of data-driven ttbar e-mu sample in place of MC
 		
 		#preselectionmumu += '*(M_uu>50)*(M_uu<80)'#fixme this is for control region checks
+		MakeBasicPlot("DeepJet_jet1","Jet1 DeepJet score",bjetbinning,preselectionmumu,NormalWeightMuMu,NormalDirectory,'standard','uujj',Rz_uujj, Rw_uvjj,Rtt_uujj,'',version_name,1000)
+		MakeBasicPlot("DeepJet_jet2","Jet2 DeepJet score",bjetbinning,preselectionmumu,NormalWeightMuMu,NormalDirectory,'standard','uujj',Rz_uujj, Rw_uvjj,Rtt_uujj,'',version_name,1000)
 		MakeBasicPlot("Pt_jet1+Pt_jet2","p_{T}(jet_{1})+p_{T}(jet_{2}) [GeV]",ptbinning2,preselectionmumu,NormalWeightMuMu,NormalDirectory,'standard','uujj',Rz_uujj, Rw_uvjj,Rtt_uujj,'',version_name,1000)
 		MakeBasicPlot("Pt_muon1+Pt_muon2","p_{T}(#mu_{1})+p_{T}(#mu_{2}) [GeV]",ptbinning2,preselectionmumu,NormalWeightMuMu,NormalDirectory,'standard','uujj',Rz_uujj, Rw_uvjj,Rtt_uujj,'',version_name,1000)
 		MakeBasicPlot("GoodVertexCount","N_{Vertices}",vbinning,preselectionmumu,NormalWeightMuMu,NormalDirectory,'standard','uujj',Rz_uujj, Rw_uvjj,Rtt_uujj,'',version_name,1000)
@@ -676,8 +682,6 @@ def main():
 		MakeBasicPlot("DPhi_muon1jet2","#Delta#phi(#mu_{1},j_{2})",dphibinning,preselectionmumu,NormalWeightMuMu,NormalDirectory,'standard','uujj',Rz_uujj, Rw_uvjj,Rtt_uujj,'',version_name,1000)
 		MakeBasicPlot("DPhi_muon2jet1","#Delta#phi(#mu_{2},j_{1})",dphibinning,preselectionmumu,NormalWeightMuMu,NormalDirectory,'standard','uujj',Rz_uujj, Rw_uvjj,Rtt_uujj,'',version_name,1000)
 		MakeBasicPlot("DPhi_muon2jet2","#Delta#phi(#mu_{2},j_{2})",dphibinning,preselectionmumu,NormalWeightMuMu,NormalDirectory,'standard','uujj',Rz_uujj, Rw_uvjj,Rtt_uujj,'',version_name,1000)
-		MakeBasicPlot("CISV_jet1","Jet1 CSV score",bjetbinning,preselectionmumu,NormalWeightMuMu,NormalDirectory,'standard','uujj',Rz_uujj, Rw_uvjj,Rtt_uujj,'',version_name,1000)
-		MakeBasicPlot("CISV_jet2","Jet2 CSV score",bjetbinning,preselectionmumu,NormalWeightMuMu,NormalDirectory,'standard','uujj',Rz_uujj, Rw_uvjj,Rtt_uujj,'',version_name,1000)
 
 		# UVJJ plots at preselection
 		
@@ -4544,6 +4548,9 @@ def GetMuMuScaleFactors( selection, FileDirectory, controlregion_1, controlregio
 	print 'Data:',N1,N2
 	print 'Z:',Z1,Z2
 	print 'TT:',T1,T2
+	print 'ST:',s1,s2
+	print 'W:',w1,w2
+	print 'VV:',v1,v2
 	print 'Other:',Other1,Other2
 
 
@@ -5642,9 +5649,9 @@ def MakeBasicPlot(recovariable,xlabel,presentationbinning,selection,weight,FileD
 
 
 	MCStack=BeautifyStack(MCStack,Label)
-	hs_rec_Signal.Draw("HISTSAME")
-	if 'final' not in tagname:
-		hs_rec_Signal2.Draw("HISTSAME")
+	#hs_rec_Signal.Draw("HISTSAME")
+	#if 'final' not in tagname:
+		#hs_rec_Signal2.Draw("HISTSAME")
  	if 'PAS' in tagname and 'final' in tagname:
 		# sysTop.Draw("F")
 		hs_bgband.Draw("E2SAME")
@@ -5698,8 +5705,8 @@ def MakeBasicPlot(recovariable,xlabel,presentationbinning,selection,weight,FileD
 	if 'final' not in tagname:
 		if 'PAS' in tagname:
 			leg.AddEntry(hs_bgband,'Unc. (stat + syst)')
-		leg.AddEntry(hs_rec_Signal,sig1name,"l")
-		leg.AddEntry(hs_rec_Signal2,sig2name,"l")
+		#leg.AddEntry(hs_rec_Signal,sig1name,"l")
+		#leg.AddEntry(hs_rec_Signal2,sig2name,"l")
 	else:
 		if 'PAS' in tagname:
 			leg.AddEntry(hs_bgband,'Unc. (stat + syst)')
@@ -5726,12 +5733,12 @@ def MakeBasicPlot(recovariable,xlabel,presentationbinning,selection,weight,FileD
  
 	if  'PAS' in tagname and 'tagfree' not in tagname:
 		#l1.DrawLatex(0.18,0.94,"CMS #it{Preliminary}      "+sqrts+", 19.7 fb^{-1}")
-		l1.DrawLatex(0.13,0.94,"#it{Preliminary}                                35.9 fb^{-1} (13 TeV)")
+		l1.DrawLatex(0.13,0.94,"#it{Preliminary}                                "+lumiInvfb+" fb^{-1} (13 TeV)")
 		#l1.DrawLatex(0.64,0.94,"5 fb^{-1} (13 TeV)")
 		l2.DrawLatex(0.15,0.84,"CMS")
 	elif  'PAS' in tagname and 'tagfree' in tagname:
 		#l1.DrawLatex(0.18,0.94,"CMS #it{Preliminary}      "+sqrts+", 19.7 fb^{-1}")
-		l1.DrawLatex(0.13,0.94,"                                                35.9 fb^{-1} (13 TeV)")
+		l1.DrawLatex(0.13,0.94,"                                                "+lumiInvfb+" fb^{-1} (13 TeV)")
 		#l1.DrawLatex(0.64,0.94,"5 fb^{-1} (13 TeV)")
 		l2.DrawLatex(0.15,0.84,"CMS")
 		if channel=='uujj':
@@ -5740,7 +5747,7 @@ def MakeBasicPlot(recovariable,xlabel,presentationbinning,selection,weight,FileD
 			l1.DrawLatex(0.155,0.77,"#mu#nujj")
 	else:
 		#l1.DrawLatex(0.18,0.94,"                          "+sqrts+", 225.57 pb^{-1}")
-		l1.DrawLatex(0.12,0.94,"#it{Preliminary}                           35.9 fb^{-1} (13 TeV)")
+		l1.DrawLatex(0.12,0.94,"#it{Preliminary}                           "+lumiInvfb+" fb^{-1} (13 TeV)")
 		l2.DrawLatex(0.15,0.84,"CMS")
 
 
@@ -8026,7 +8033,9 @@ def blind(h,name,num,tag,chan):
 	#print name
 	#name = h.GetName()
 	blindstart = 9999
-	if 'St' in name and 'uujj' in chan:
+	if name == 'M_uu':
+		blindstart = 300
+	elif 'St' in name and 'uujj' in chan:
 		blindstart = 1500
 	elif 'uujj2' in name:
 		blindstart = 800

--- a/NTupleAnalyzer_nanoAOD.py
+++ b/NTupleAnalyzer_nanoAOD.py
@@ -149,7 +149,7 @@ _kinematicvariables += ['passTrigMu1','passTrigMu2']
 _kinematicvariables += ['muonIndex1','muonIndex2']
 _kinematicvariables += ['jetIndex1','jetIndex2']
 _kinematicvariables += ['ptHat']
-_kinematicvariables += ['CISV_jet1','CISV_jet2']
+_kinematicvariables += ['DeepJet_jet1','DeepJet_jet2']
 _kinematicvariables += ['bTagSF_jet1','bTagSF_jet2']
 _kinematicvariables += ['PULoosej1','PUMediumj1','PUTightj1']
 _kinematicvariables += ['PULoosej2','PUMediumj2','PUTightj2']
@@ -1441,7 +1441,7 @@ def TightIDJets(T,met,variation,isdata):
 	jetinds = []
 	NHFs = []
 	NEMFs = []
-	CSVscores = []
+	DeepJetScores = []
 	bTagSFs = []
 	PUIds = []
 	for n in range(len(_PFJetPt)):
@@ -1472,9 +1472,9 @@ def TightIDJets(T,met,variation,isdata):
 				jetinds.append(n)
 				NHFs.append(T.Jet_neHEF[n])
 				NEMFs.append(T.Jet_neEmEF[n])
-				CSVscores.append(T.Jet_btagCSVV2[n])
+				DeepJetScores.append(T.Jet_btagDeepFlavB[n])
 				if 'SingleMuon' in name or 'SingleElectron' in name or 'DoubleMuon' in name or 'DoubleEG' in name: bTagSFs.append(1.0)
-				else: bTagSFs.append(T.Jet_btagSF_deepcsv_M[n])
+				else: bTagSFs.append(T.Jet_btagSF_deepjet_M[n])
 				PUIds.append([(T.Jet_puId[n] & 0x4)>0,(T.Jet_puId[n] & 0x2)>0,(T.Jet_puId[n] & 0x1)>0])
 			else:
 				if _PFJetPt[n] > JetFailThreshold:
@@ -1482,7 +1482,7 @@ def TightIDJets(T,met,variation,isdata):
 
 	# print met.Pt()
 
-	return [jets,jetinds,met,JetFailThreshold,NHFs,NEMFs,CSVscores,bTagSFs,PUIds]
+	return [jets,jetinds,met,JetFailThreshold,NHFs,NEMFs,DeepJetScores,bTagSFs,PUIds]
 def GetLLJJMasses(l1,l2,j1,j2):
 	# Purpose: For LLJJ channels, this function returns two L-J Masses, corresponding to the
 	#         pair of L-Js which minimizes the difference between LQ masses in the event
@@ -1762,7 +1762,7 @@ def FullKinematicCalculation(T,variation):
 	# taus_forjetsep = TausForJetSeparation(T)
 	[electrons,electroninds,met] = HEEPElectrons(T,met,variation)
 	# ID Jets and filter from muons
-	[jets,jetinds,met,failthreshold,neutralhadronEF,neutralemEF,btagCSVscores,btagSFs,PUIds] = TightIDJets(T,met,variation,isData)
+	[jets,jetinds,met,failthreshold,neutralhadronEF,neutralemEF,btagDeepJetScores,btagSFs,PUIds] = TightIDJets(T,met,variation,isData)
 	# jets = GeomFilterCollection(jets,muons_forjetsep,0.5)
 	jets = GeomFilterCollection(jets,muons,0.5)
 	jets = GeomFilterCollection(jets,electrons,0.5)
@@ -1801,14 +1801,14 @@ def FullKinematicCalculation(T,variation):
 		jets.append(EmptyLorentz)
 		neutralhadronEF.append(0.0)
 		neutralemEF.append(0.0)
-		btagCSVscores.append(-5.0)
+		btagDeepJetScores.append(-5.0)
 		btagSFs.append(-5.0)
 		PUIds.append([-5.0,-5.0,-5.0])
 	if len(jets) < 2 : 
 		jets.append(EmptyLorentz)
 		neutralhadronEF.append(0.0)
 		neutralemEF.append(0.0)		
-		btagCSVscores.append(-5.0)
+		btagDeepJetScores.append(-5.0)
 		btagSFs.append(-5.0)
 		PUIds.append([-5.0,-5.0,-5.0])
 	_ismuon_muon1 = 1.0
@@ -1857,7 +1857,7 @@ def FullKinematicCalculation(T,variation):
 	[_nhefj1,_nhefj2,_nemefj1,_nemefj2] = [neutralhadronEF[0],neutralhadronEF[1],neutralemEF[0],neutralemEF [1]]
 	[_ptmet,_etamet,_phimet] = [met.Pt(),0,met.Phi()]
 	[_xmiss,_ymiss] = [met.Px(),met.Py()]
-	[_CSVj1,_CSVj2] = [btagCSVscores[0],btagCSVscores[1]]
+	[_deepJetj1,_deepJetj2] = [btagDeepJetScores[0],btagDeepJetScores[1]]
 	[_btagSF1,_btagSF2] = [btagSFs[0],btagSFs[1]]
 	[_PULoosej1,_PUMediumj1,_PUTightj1] = PUIds[0]
 	[_PULoosej2,_PUMediumj2,_PUTightj2] = PUIds[1]
@@ -1994,7 +1994,7 @@ def FullKinematicCalculation(T,variation):
 	toreturn += [_muonInd1,_muonInd2]
 	toreturn += [_jetInd1,_jetInd2]
 	toreturn += [_ptHat]
-	toreturn += [_CSVj1,_CSVj2]
+	toreturn += [_deepJetj1,_deepJetj2]
 	toreturn += [_btagSF1,_btagSF2]
 	toreturn += [_PULoosej1,_PUMediumj1,_PUTightj1]
 	toreturn += [_PULoosej2,_PUMediumj2,_PUTightj2]

--- a/NTupleInfo2016Full_stockNano.csv
+++ b/NTupleInfo2016Full_stockNano.csv
@@ -12,11 +12,11 @@ Run2016H-Nano25Oct2019,1,1,SingleMuData,Cert_271036-284044_13TeV_ReReco_07Aug201
 #
 #DY+Jets
 #
-DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8,5765.4,81781064,ZJetsInc_amcNLO,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
-DYJetsToLL_M-10to50,18610,3267618990080,ZJetsM10-50,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
-DYJetsToLL_Zpt-0To50,5352.57924,571611377888,ZJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
-DYJetsToLL_Pt-50To100,363.81428,119259750736,ZJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
-DYJetsToLL_Pt-100To250,84.014804,16717612160,ZJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
+DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8,5765.4,1897141622528,ZJetsInc_amcNLO,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
+DYJetsToLL_M-10to50,18610,3267618930688,ZJetsM10-50,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
+DYJetsToLL_Zpt-0To50,5352.57924,571611375104,ZJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
+DYJetsToLL_Pt-50To100,363.81428,119259751168,ZJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
+DYJetsToLL_Pt-100To250,84.014804,16717612216,ZJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
 DYJetsToLL_Pt-250To400,3.22826,152558724,ZJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
 DYJetsToLL_Pt-400To650,0.436041,1458753,ZJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
 DYJetsToLL_Pt-650ToInf,0.040981,36542,ZJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
@@ -27,18 +27,18 @@ TT_TuneCUETP8M2T4_13TeV-powheg-pythia8,831.76,153790053,TTBar_Inc,0,/store/group
 #
 #Single Top
 #
-ST_s-channel_4f,10.32,3370668,SingleTop,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
-ST_t-channel_top_5f_leptDecays,136.02,255713568,SingleTop,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
-ST_t-channel_antitop_5f_leptDecays,80.95,99386815,SingleTop,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
+ST_s-channel_4f_leptonDecays,3.38,3370668,SingleTop,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
+ST_t-channel_top_5f_leptDecays,44.51,255713568,SingleTop,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
+ST_t-channel_antitop_5f_leptDecays,26.49,99386815,SingleTop,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
 ST_tW_top_5f_inclusiveDecays,35.85,6952830,SingleTop,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
 ST_tW_antitop_5f_inclusiveDecays,35.85,6933094,SingleTop,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
 #
 #W+Jets 
 #
-WJetsToLNu_Wpt-0To50_,57297.39264,16926855266688,WJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/ 
-#WJetsToLNu_Wpt-50To100_,3298.3733,176322770912,WJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/ # Not on DAS yet
-WJetsToLNu_Pt-100To250_,689.7496,176322770912,WJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
-WJetsToLNu_Pt-250To400_,24.5069,617769192,WJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
+WJetsToLNu_Wpt-0To50_,57297.3926,16926855294848,WJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
+#WJetsToLNu_Wpt-50To100_,3298.3733,0,WJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/ # Not on DAS yet
+WJetsToLNu_Pt-100To250_,689.7496,176322771808,WJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
+WJetsToLNu_Pt-250To400_,24.5069,617769196,WJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
 WJetsToLNu_Pt-400To600_,3.110131,11692372,WJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
 WJetsToLNu_Pt-600ToInf_,0.468318,1830415,WJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
 #
@@ -51,9 +51,9 @@ WZTo3LNu,4.42965,97448994,DiBoson_amcNLO,0,/store/group/phys_exotica/leptonsPlus
 WZTo1L3Nu,3.033,9357734,DiBoson_amcNLO,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
 WZTo2L2Q,5.595,234019000,DiBoson_amcNLO,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
 WZTo1L1Nu2Q,10.71,422045312,DiBoson_amcNLO,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
-WZTo2Q2Nu,6.324,181249866,DiBoson_amcNLO,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
-ZZTo4L,1.212,20479340,DiBoson_amcNLO,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
+WZTo2Q2Nu,6.324,181249868,DiBoson_amcNLO,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
+ZZTo4L,1.212,20479341,DiBoson_amcNLO,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
 ZZTo2L2Q,3.22,78447679,DiBoson_amcNLO,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
-ZZTo2Q2Nu,4.04,18470622,DiBoson_amcNLO,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
-ZZTo4Q,6.896587,340455191,DiBoson_amcNLO,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
+ZZTo2Q2Nu,4.04,199025623,DiBoson_amcNLO,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
+ZZTo4Q,6.896587,340455188,DiBoson_amcNLO,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/
 VVTo2L2Nu,11.95,153860938,DiBoson_amcNLO,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/LQ2/2016/gmadigan/

--- a/NTupleInfo2017Full_stockNano.csv
+++ b/NTupleInfo2017Full_stockNano.csv
@@ -12,7 +12,7 @@ Run2017F-Nano25Oct2019,1,1,SingleMuData,Cert_294927-306462_13TeV_EOY2017ReReco_C
 #
 DYJetsToLL_M-10to50,18610,39821167,ZJetsM10-50,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/gmadigan/
 #DYJetsToLL_Zpt-0To50,5352.57924,571611377888,ZJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/gmadigan/ # Not on DAS
-#DYJetsToLL_Pt-50To100,363.81428,119259750736,ZJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/gmadigan/ # Not on DAS
+DYJetsToLL_Pt-50To100,363.81428,119259750736,ZJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/gmadigan/
 DYJetsToLL_Pt-100To250,84.014804,15432503518,ZJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/gmadigan/
 DYJetsToLL_Pt-250To400,3.22826,172400452,ZJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/gmadigan/
 DYJetsToLL_Pt-400To650,0.436041,2057114,ZJetsPtBin,0,/store/group/phys_exotica/leptonsPlusJets/LQ/stockNanoSkim/gmadigan/


### PR DESCRIPTION
Updated b-tagger to use Deep Flavor B (DeepJet). Added 'year' option to results producer for year-specific quantities, e.g., input trees, lumis, trigger paths. Adjusted 2016 and 2017 ntuple info (added some files, fixed some xsecs, event counts).