### PR TITLE
Significant changes to muon selection and systematics in analyzer

### DIFF
--- a/NTupleAnalyzer_nanoAOD.py
+++ b/NTupleAnalyzer_nanoAOD.py
@@ -1188,10 +1188,10 @@ def SmearMuonCollections(_ptCollection, _etaCollection, _phiCollection, isSystem
 	return [smearedPtCollection, smearedEtaCollection, smearedPhiCollection]
 
 def SortCollections(listOfCollections):
-	# Takes a list of collections (e.g., pT, eta, phi)
-	# and sorts the first collection while also sorting 
-	# the other collections accordingly.
-	# Returns the reordered collections as a list
+	# Takes a list of collections (e.g., pT, eta, phi) and sorts the first collection by value (high to low).
+	# Simultaniously, the other collections are reordered identically to the first. 
+	# Returns the reordered collections as a list.
+	# Make sure Pt cocktailis the first collection in ListOfCollections!
 
 	zippedCollections = zip(*listOfCollections) # zip unpacked (*) collections together into a list of tuples
 	sortedCollections = sorted(zippedCollections, reverse=True) # reorder all collections simultaniously by pT


### PR DESCRIPTION
Corrected Muon POG errors and typos in analyzer for MER smearing and systematics. Added in support for GE method when calculating MES (no corrections needed, just systematics). Made sure no systematics computed for data. Implemented a "sorting" function to resort all collections (pt, eta, phi, charge, iso, id, etc.) based off updated pT assignment (TuneP, resolution smearing, but not for systematic variations). Required extensive modification to the entire TightHighPtIDMuons function. 