### PR TITLE
Set updated arch and CMSSW vers in Condor submission

### DIFF
--- a/AnalyzerMakerFastLocalHTCondor.py
+++ b/AnalyzerMakerFastLocalHTCondor.py
@@ -491,9 +491,9 @@ def MakeJobs(njobs):
 
 
 		#fixme changed from 8_0_26_patch1 to 10_2_9 for btagcalibration
-		subber.write('setenv SCRAM_ARCH slc6_amd64_gcc700\n\n')
+		subber.write('setenv SCRAM_ARCH slc7_amd64_gcc700\n\n')
 		subber.write('source /cvmfs/cms.cern.ch/cmsset_default.csh\n')
-		subber.write('scram project CMSSW CMSSW_10_2_18\ncd CMSSW_10_2_18/src\n')#')scramv1 runtime -csh\ncd -\n\n')
+		subber.write('scram project CMSSW CMSSW_10_6_4\ncd CMSSW_10_6_4/src\n')#')scramv1 runtime -csh\ncd -\n\n')
 		subber.write('cmsenv\n')
 		#subber.write('git cms-addpkg CondTools/BTau\n')
 		#subber.write('git cms-addpkg CondFormats/BTauObjects\n')
@@ -538,7 +538,7 @@ def MakeJobs(njobs):
 		#subber.write('\non_exit_remove         = (ExitBySignal == False) && (ExitCode == 0)')
 		#subber.write('\nmax_retries            = 3')
 		#subber.write('\nrequirements = Machine =!= LastRemoteHost')
-                subber.write('\nrequirements = (OpSysAndVer =?= "SLCern6")')
+                subber.write('\nrequirements = (OpSysAndVer =?= "CentOS7")')
 		subber.write('\nqueue\n')
 
 		subber.close()


### PR DESCRIPTION
Updates to AnalyzerMakerFastLocalHTCondor.py to use different architecture and CMSSW release. Necessary to run TMVA modules in analyzer that add BDT weights to trees.